### PR TITLE
Bugfix/facebook login

### DIFF
--- a/app/src/main/java/fga/mds/gpp/trezentos/Controller/UserAccountControl.java
+++ b/app/src/main/java/fga/mds/gpp/trezentos/Controller/UserAccountControl.java
@@ -160,12 +160,13 @@ public class UserAccountControl {
     //Sign-in Facebook TODO
     public void authenticateSignInFb(JSONObject object){
         try{
-            String name = object.getString("PersonFirstName");
+            String fFirstName = object.getString("PersonFirstName");
+            String fLastName = object.getString("PersonLastName");
             String fEmail = object.getString("PersonEmail");
             UserAccount fbUserAccount = new UserAccount();
             fbUserAccount.setEmail(fEmail);
-            //fbUserAccount.setName(name);
-
+            fbUserAccount.setFirstName(fFirstName);
+            fbUserAccount.setLastName(fLastName);
 
         }catch(JSONException | UserException e){
             e.printStackTrace();
@@ -174,18 +175,21 @@ public class UserAccountControl {
 
     public void signInUserFromFacebook(JSONObject object){
         SharedPreferences session = PreferenceManager.getDefaultSharedPreferences(context);
-        String nome = null, email = null;
+        String fName = null, email = null, lName = null;
 
         try {
-            nome = object.getString("name");
+            fName = object.getString("first_name");
+            lName = object.getString("last_name");
             email = object.getString("email");
+
         } catch (JSONException e) {
             e.printStackTrace();
         }
         session.edit()
                 .putBoolean("IsUserLogged", true)
                 .putString("userEmail", email)
-                .putString("userName", nome)
+                .putString("userFirstName", fName)
+                .putString("userLastName", lName)
                 .apply();
     }
     //End Sign-in Facebook

--- a/app/src/main/java/fga/mds/gpp/trezentos/Controller/UserAccountControl.java
+++ b/app/src/main/java/fga/mds/gpp/trezentos/Controller/UserAccountControl.java
@@ -29,6 +29,7 @@ public class UserAccountControl {
     final Context context;
     private UserAccount userAccount;
     private UserAccount fbUserAccount;
+    private Boolean isFromFacebook = false;
 
 
     private UserAccountControl(final Context context){
@@ -157,7 +158,7 @@ public class UserAccountControl {
 
 
 
-    //Sign-in Facebook TODO
+    //Sign-in Facebook
     public void authenticateSignInFb(JSONObject object){
         try{
             String fFirstName = object.getString("PersonFirstName");
@@ -191,6 +192,8 @@ public class UserAccountControl {
                 .putString("userFirstName", fName)
                 .putString("userLastName", lName)
                 .apply();
+
+        isFromFacebook = true;
     }
     //End Sign-in Facebook
 
@@ -271,7 +274,7 @@ public class UserAccountControl {
 
     public boolean isLoggedUser(){
         SharedPreferences session = PreferenceManager.getDefaultSharedPreferences(context);
-        return session.getBoolean("IsUserLogged", false);
+        return (session.getBoolean("IsUserLogged", false) || isFromFacebook);
     }
     //End Common
 

--- a/app/src/main/java/fga/mds/gpp/trezentos/View/Activity/MainActivity.java
+++ b/app/src/main/java/fga/mds/gpp/trezentos/View/Activity/MainActivity.java
@@ -110,7 +110,7 @@ public class MainActivity extends AppCompatActivity{
         startActivity(new Intent(getApplicationContext(), SearchActivity.class));
     }
     private void goSignInScreen() {
-        Intent intent = new Intent(getApplicationContext(), SignInActivity.class);
+        Intent intent = new Intent(MainActivity.this, SignInActivity.class);
 
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK |
                 Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/app/src/main/java/fga/mds/gpp/trezentos/View/Activity/SignInActivity.java
+++ b/app/src/main/java/fga/mds/gpp/trezentos/View/Activity/SignInActivity.java
@@ -27,6 +27,7 @@ import org.json.JSONObject;
 import java.util.Arrays;
 import fga.mds.gpp.trezentos.Controller.UserAccountControl;
 import fga.mds.gpp.trezentos.Exception.UserException;
+import fga.mds.gpp.trezentos.Model.UserAccount;
 import fga.mds.gpp.trezentos.R;
 import fga.mds.gpp.trezentos.View.AboutOnLogin;
 
@@ -134,9 +135,9 @@ public class SignInActivity extends AppCompatActivity implements View.OnClickLis
         }
     }
 
-
-
     private void facebookAPI(){
+        userAccountControl = UserAccountControl.getInstance(getApplicationContext());
+
         callbackManager = CallbackManager.Factory.create();
         loginFacebook = findViewById(R.id.button_sign_in_facebook);
         loginFacebook.setReadPermissions(Arrays.asList("email", "public_profile"));
@@ -145,6 +146,7 @@ public class SignInActivity extends AppCompatActivity implements View.OnClickLis
             @Override
             public void onSuccess(LoginResult loginResult){
                 facebookLogin(loginResult);
+                userAccountControl.changeUserToLogged();
                 goToMain();
             }
 
@@ -193,7 +195,6 @@ public class SignInActivity extends AppCompatActivity implements View.OnClickLis
                         userAccountControl.signInUserFromFacebook(jsonObject);
                     }
                 });
-
         Bundle parameters = new Bundle();
         parameters.putString("fields", "id,first_name,last_name,email,gender");
         request.setParameters(parameters);

--- a/app/src/main/java/fga/mds/gpp/trezentos/View/Activity/SignInActivity.java
+++ b/app/src/main/java/fga/mds/gpp/trezentos/View/Activity/SignInActivity.java
@@ -5,6 +5,7 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
@@ -194,7 +195,7 @@ public class SignInActivity extends AppCompatActivity implements View.OnClickLis
                 });
 
         Bundle parameters = new Bundle();
-        parameters.putString("fields", "id,name,email,gender");
+        parameters.putString("fields", "id,first_name,last_name,email,gender");
         request.setParameters(parameters);
         request.executeAsync();
 
@@ -228,7 +229,7 @@ public class SignInActivity extends AppCompatActivity implements View.OnClickLis
     }
 
     private void goToMain() {
-        Intent intentGoMainActivity = new Intent(SignInActivity.this, MainActivity.class);
+        Intent intentGoMainActivity = new Intent(getApplicationContext(), MainActivity.class);
 
         intentGoMainActivity.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK |
                 Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/app/src/main/java/fga/mds/gpp/trezentos/View/Fragment/UserFragment.java
+++ b/app/src/main/java/fga/mds/gpp/trezentos/View/Fragment/UserFragment.java
@@ -89,10 +89,10 @@ public class UserFragment extends Fragment implements View.OnClickListener{
     public void onClick(View view){
         switch (view.getId()){
             case R.id.exit_button: {
-                //LoginManager.getInstance().logOut();
 
                 UserAccountControl userAccountControl = UserAccountControl.getInstance(getApplicationContext());
                 userAccountControl.logOutUser();
+                userAccountControl.disconnectFromFacebook();
 
                 goLoginScreen();
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,7 +43,7 @@
     <string name="msg_signup_success">Usuário cadastrado com sucesso!</string>
     <string name="msg_class_success">Sucesso</string>
     <!-- Login -->
-    <string name="facebook_app_id">1840540606200745</string>
+    <string name="facebook_app_id">2113304315624784</string>
     <string name="sign_up_text">Cadastrar</string>
     <string name="already_sign_up"> <u> Já sou cadastrado </u></string>
     <string name="error_login">Ocorreu um erro ao entrar</string>


### PR DESCRIPTION
## Modificações

Antes | Depois
--------- | ------
Usuário desconectava do aplicativo, mas não do face | Ao clicar em "Sair", o usuário é desconectado tanto do aplicativo quanto do Facebook
Ao fazer o login pelo Facebook, o usuário sem era redirecionado para a página de login | Ao fazer o login pelo Facebook, o usuário é redirecionado para a página principal da aplicação
Quando o login pelo Facebook era efetivado, não apareciam informações como o nome do usuário | Foi adicionado a coleta do primeiro e último nome através dos dados do Facebook

## Issue
#18 

## Problemas Encontrados
* Quando conectado com o Facebook não estão sendo adicionadas salas ao usuário. Tanto pelo método de criação como pela adição de uma sala já existente, não aparecem salas na tela principal.
* O Facebook não disponibiliza o telefone do usuário, consequentemente, usuários que efetuam o login por ele não possuem telefone cadastrado.

Será criada uma nova issue para esses problemas, visto que essa se trata apenas do login.
