### PR TITLE
Solve #120 Ignorar arquivo build_file_checksums.ser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ gen-external-apklibs
 .scannerwork/
 
 .DS_Store
+
+## Remove the conflict file
+.idea/caches/build_file_checksums.ser

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,7 @@
-
-# Created by https://www.gitignore.io/api/android
-
-### Android ###
 # Built application files
 *.apk
 *.ap_
+*.aab
 
 # Files for the ART/Dalvik VM
 *.dex
@@ -36,33 +33,35 @@ proguard/
 # Android Studio captures folder
 captures/
 
-# Intellij
+# IntelliJ
 *.iml
 .idea/workspace.xml
 .idea/tasks.xml
 .idea/gradle.xml
+.idea/assetWizardSettings.xml
 .idea/dictionaries
 .idea/libraries
-.idea/kotlinc.xml
-.idea/misc.xml
+.idea/caches
 
 # Keystore files
-*.jks
+# Uncomment the following lines if you do not want to check your keystore files in.
+#*.jks
+#*.keystore
 
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild
+
+# Google Services (e.g. APIs or Firebase)
+google-services.json
 
 # Freeline
 freeline.py
 freeline/
 freeline_project_description.json
 
-### Android Patch ###
-gen-external-apklibs
-
-.scannerwork/
-
-.DS_Store
-
-## Remove the conflict file
-.idea/caches/build_file_checksums.ser
+# fastlane
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots
+fastlane/test_output
+fastlane/readme.md


### PR DESCRIPTION
## Descrição 

Foi adicionado ao gitignore o arquivo build_file_checksums.ser que estava sendo conflitante no projeto, assim não havendo mais a possibilidade de ser adicionado equivocadamente. 

## Resolve Issues
#120 
