### PR TITLE
Solve #111 Trocar cores dos grupos da prova

### DIFF
--- a/app/src/main/res/layout/groups_item.xml
+++ b/app/src/main/res/layout/groups_item.xml
@@ -2,6 +2,7 @@
 <android.support.v7.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_centerHorizontal="true"
     android:layout_centerVertical="true"
     card_view:cardElevation="4dp"
@@ -41,9 +42,9 @@
             android:background="#424242">
 
                 <View
-                    android:background="#50ff35"
-                    android:layout_width="10dp"
-                    android:layout_height="wrap_content" />
+                    android:layout_width="9dp"
+                    android:layout_height="wrap_content"
+                    android:background="#2424E6" />
 
                 <TextView
                     android:layout_weight="4"
@@ -306,9 +307,9 @@
                 android:background="#424242">
 
                 <View
-                    android:background="#ff462d"
                     android:layout_width="10dp"
-                    android:layout_height="wrap_content" />
+                    android:layout_height="wrap_content"
+                    android:background="#09AE22" />
 
                 <TextView
                     android:layout_weight="4"


### PR DESCRIPTION
## Descrição 

Foram alteradas as cores na tela de "grupos", no cadastro de provas, que não são interessantes para os usuários.

## Resolve (Issues)

#111 
